### PR TITLE
Remove usage of deprecated css selector

### DIFF
--- a/styles/atom-rtags.less
+++ b/styles/atom-rtags.less
@@ -3,7 +3,7 @@
 
 // result markers
 atom-text-editor,
-atom-text-editor::shadow {
+atom-text-editor.editor {
   .find-result .region {
     background-color: transparent;
     border-radius: @component-border-radius;
@@ -27,7 +27,7 @@ atom-text-editor::shadow {
 
 atom-workspace.find-visible {
   atom-text-editor,
-  atom-text-editor::shadow {
+  atom-text-editor.editor {
     .find-result,
     .current-result {
       display: block;
@@ -260,7 +260,7 @@ atom-workspace.find-visible {
   }
 }
 
-.find-container atom-text-editor::shadow, .replace-container atom-text-editor::shadow {
+.find-container atom-text-editor.editor, .replace-container atom-text-editor.editor {
   // Styles for regular expression highlighting
   .regexp {
     .escape {


### PR DESCRIPTION
Remove usage of ::shadow selector in .less, using instead .editor to conform with v1.13.0